### PR TITLE
Delete useless judgment

### DIFF
--- a/src/redis/cmd.rs
+++ b/src/redis/cmd.rs
@@ -664,9 +664,7 @@ impl CmdCodec {
             sum += count;
         }
 
-        if !dst.has_remaining_mut() {
-            dst.reserve(1);
-        }
+        dst.reserve(1);
         dst.put_u8(RESP_INT);
         let buf = format!("{}", sum);
         dst.extend_from_slice(buf.as_bytes());
@@ -680,9 +678,7 @@ impl CmdCodec {
     }
 
     fn merge_encode_join(&mut self, subs: Vec<Cmd>, dst: &mut BytesMut) -> AsResult<()> {
-        if !dst.has_remaining_mut() {
-            dst.reserve(1);
-        }
+        dst.reserve(1);
         dst.put_u8(RESP_ARRAY);
 
         let count = subs.len();
@@ -773,9 +769,7 @@ impl HandleCodec {
             sum += count;
         }
 
-        if !dst.has_remaining_mut() {
-            dst.reserve(1);
-        }
+        dst.reserve(1);
         dst.put_u8(RESP_INT);
         let buf = format!("{}", sum);
         dst.extend_from_slice(buf.as_bytes());
@@ -789,9 +783,7 @@ impl HandleCodec {
     }
 
     fn merge_encode_join(&mut self, subs: Vec<Cmd>, dst: &mut BytesMut) -> AsResult<()> {
-        if !dst.has_remaining_mut() {
-            dst.reserve(1);
-        }
+        dst.reserve(1);
         dst.put_u8(RESP_ARRAY);
 
         let count = subs.len();

--- a/src/redis/resp.rs
+++ b/src/redis/resp.rs
@@ -224,18 +224,14 @@ impl Resp {
             RESP_STRING | RESP_ERROR | RESP_INT => {
                 let data = self.data.as_ref().expect("never empty");
                 let my_len = 1 + 2 + data.len();
-                if dst.remaining_mut() < my_len {
-                    dst.reserve(my_len);
-                }
+                dst.reserve(my_len);
                 dst.put_u8(self.rtype);
                 dst.extend_from_slice(data);
                 dst.extend_from_slice(BYTES_CRLF);
                 Ok(1 + 2 + data.len())
             }
             RESP_BULK => {
-                if !dst.has_remaining_mut() {
-                    dst.reserve(1);
-                }
+                dst.reserve(1);
                 dst.put_u8(self.rtype);
                 if self.is_null() {
                     dst.extend_from_slice(BYTES_NULL_RESP);
@@ -252,9 +248,7 @@ impl Resp {
                 Ok(1 + len_len + 2 + data_len + 2)
             }
             RESP_ARRAY => {
-                if dst.remaining_mut() < 5 {
-                    dst.reserve(5);
-                }
+                dst.reserve(5);
 
                 dst.put_u8(self.rtype);
                 if self.is_null() {


### PR DESCRIPTION
Why delete these judgments ？

docs here：[https://docs.rs/bytes/0.4.11/bytes/struct.BytesMut.html#method.reserve](https://docs.rs/bytes/0.4.11/bytes/struct.BytesMut.html#method.reserve)

> More than additional bytes may be reserved in order to avoid frequent reallocations. A call to reserve may result in an allocation.

There will be no allocation of memory unless necessary.

The source code can also be seen, these judgments have been implemented inside the function:
[https://github.com/carllerche/bytes/blob/v0.4.x/src/bytes.rs#L2243:L2251](https://github.com/carllerche/bytes/blob/v0.4.x/src/bytes.rs#L2243:L2251)

If the compiler is not optimized, there will be more function calls and judgment instructions, which are actually not needed.
